### PR TITLE
index.html에서 Barlow 불러오기

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -30,6 +30,9 @@
 
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Barlow:ital,wght@0,100;0,200;0,300;0,400;0,500;0,600;0,700;0,800;0,900;1,100;1,200;1,300;1,400;1,500;1,600;1,700;1,800;1,900&display=block"
+    rel="stylesheet" />
 
   <title>EXIF Frame-PC</title>
 

--- a/web/src/fonts/index.ts
+++ b/web/src/fonts/index.ts
@@ -1,4 +1,5 @@
 enum Font {
+  // Barlow는 index.html에서 로드합니다.
   Digital7 = 'digital-7',
   Poxel = 'poxel',
   DINAlternateBold = 'din-alternate-bold',


### PR DESCRIPTION
업스트림과 같이 Google Fonts에서 Barlow를 불러오도록 했으며, Fonts enum에는 추가하지 않았습니다.

Fixes #1.